### PR TITLE
Use nonbundled rubocop if rubocop-prefer-system-executable is set

### DIFF
--- a/rubocop.el
+++ b/rubocop.el
@@ -68,6 +68,11 @@
   :group 'rubocop
   :type 'string)
 
+(defcustom rubocop-prefer-system-executable nil
+  "Runs rubocop with the system executable even if inside a bundled project."
+  :group 'rubocop
+  :type 'boolean)
+
 (defun rubocop-local-file-name (file-name)
   "Retrieve local filename if FILE-NAME is opened via TRAMP."
   (cond ((tramp-tramp-file-p file-name)
@@ -111,7 +116,7 @@ When NO-ERROR is non-nil returns nil instead of raise an error."
   "Build the full command to be run based on COMMAND and PATH.
 The command will be prefixed with `bundle exec` if RuboCop is bundled."
   (concat
-   (if (rubocop-bundled-p) "bundle exec " "")
+   (if (and (not rubocop-prefer-system-executable) (rubocop-bundled-p)) "bundle exec " "")
    command
    (rubocop-build-requires)
    " "


### PR DESCRIPTION
### Motivation

I'm using a dockerized setup for a few Rails apps and sometimes it gets out of sync with my local machine - so `bundle install` requires installing a bunch of gems that shouldn't be required for quick edits or something of the sort.

Unless there's a _good reason_ for using the bundled Rubocop (I'm not aware if using the bundled `rubocop` is any different from running it as a gem, provided the version is the same), would you be OK with merging this? Since it's optional, and the default is to keep previous behavior, I _believe_ it should be harmless.